### PR TITLE
Support doctests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,9 @@ jobs:
         # Still run doc tests even if lib/integration tests fail:
         if: ${{ !cancelled() }}
         env:
-          # This ensures the citra logs and video output get put in a directory where the
-          # artifact upload can find them (instead of being removed from the tmpdir)
-          RUSTDOCFLAGS: " --persist-doctests ${{ env.GITHUB_WORKSPACE }}/target/armv6k-nintendo-3ds/debug/doctests"
+          # This ensures the citra logs and video output get persisted to a
+          # directory where the artifact upload can find them.
+          RUSTDOCFLAGS: " --persist-doctests target/armv6k-nintendo-3ds/debug/doctests"
         uses: ./run-tests
         with:
           working-directory: test-runner
@@ -82,5 +82,5 @@ jobs:
         with:
           name: citra-logs-${{ matrix.toolchain }}
           path: |
-            target/armv6k-nintendo-3ds/debug/**/*.txt
-            target/armv6k-nintendo-3ds/debug/**/*.webm
+            test-runner/target/armv6k-nintendo-3ds/debug/**/*.txt
+            test-runner/target/armv6k-nintendo-3ds/debug/**/*.webm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,18 +63,17 @@ jobs:
           working-directory: test-runner
           args: -- -v
 
-      # TODO(#4): run these suckers
-      # - name: Build and run doc tests
-      #   # Let's still run doc tests even if lib/integration tests fail:
-      #   if: ${{ !cancelled() }}
-      #   env:
-      #     # This ensures the citra logs and video output gets put in a directory
-      #     # where we can upload as artifacts
-      #     RUSTDOCFLAGS: " --persist-doctests ${{ env.GITHUB_WORKSPACE }}/target/armv6k-nintendo-3ds/debug/doctests"
-      #   uses: ./run-tests
-      #   with:
-      #     working-directory: test-runner
-      #     args: --doc -- -v
+      - name: Build and run doc tests
+        # Still run doc tests even if lib/integration tests fail:
+        if: ${{ !cancelled() }}
+        env:
+          # This ensures the citra logs and video output get put in a directory where the
+          # artifact upload can find them (instead of being removed from the tmpdir)
+          RUSTDOCFLAGS: " --persist-doctests ${{ env.GITHUB_WORKSPACE }}/target/armv6k-nintendo-3ds/debug/doctests"
+        uses: ./run-tests
+        with:
+          working-directory: test-runner
+          args: --doc -- -v
 
       - name: Upload citra logs and capture videos
         uses: actions/upload-artifact@v3

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ jobs:
       volumes:
         # This is required so the test action can `docker run` the runner:
         - '/var/run/docker.sock:/var/run/docker.sock'
-        # This is required so doctest artifacts are accessible to the action:
-        - '/tmp:/tmp'
 
     steps:
       - name: Checkout branch

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In `lib.rs` and any integration test files:
 ```
 
 Then use the `setup` and `run-tests` actions in your github workflow. This
-example shows the default value for each of the inputs:
+example shows the default value for each of the inputs.
 
 ```yml
 jobs:
@@ -61,3 +61,6 @@ jobs:
           # https://github.com/actions/runner/issues/2058
           working-directory: ${GITHUB_WORKSPACE}
 ```
+
+See [`ci.yml`](.github/workflows/ci.yml) to see a full lint and test workflow
+using these actions (including uploading output artifacts from the tests).

--- a/run-tests/Dockerfile
+++ b/run-tests/Dockerfile
@@ -8,11 +8,7 @@ ARG CITRA_CHANNEL=nightly
 ARG CITRA_RELEASE=1995
 RUN download_citra ${CITRA_CHANNEL} ${CITRA_RELEASE}
 
-<<<<<<< Updated upstream:run-tests/Dockerfile
 FROM devkitpro/devkitarm:latest as devkitarm
-=======
-FROM devkitpro/devkitarm as devkitarm
->>>>>>> Stashed changes:Dockerfile
 
 # For some reason, citra isn't always happy when you try to run it for the first time,
 # so we build a simple dummy program to force it to create its directory structure

--- a/run-tests/Dockerfile
+++ b/run-tests/Dockerfile
@@ -8,7 +8,11 @@ ARG CITRA_CHANNEL=nightly
 ARG CITRA_RELEASE=1995
 RUN download_citra ${CITRA_CHANNEL} ${CITRA_RELEASE}
 
+<<<<<<< Updated upstream:run-tests/Dockerfile
 FROM devkitpro/devkitarm:latest as devkitarm
+=======
+FROM devkitpro/devkitarm as devkitarm
+>>>>>>> Stashed changes:Dockerfile
 
 # For some reason, citra isn't always happy when you try to run it for the first time,
 # so we build a simple dummy program to force it to create its directory structure

--- a/run-tests/action.yml
+++ b/run-tests/action.yml
@@ -1,9 +1,9 @@
 name: Cargo 3DS Test
 description: >
   Run `cargo 3ds test` executables using Citra. Note that to use this action,
-  you must mount `/var/run/docker.sock:/var/run/docker.sock` and `/tmp:/tmp` into
-  the container so that the runner image can be built and doctest artifacts can
-  be found, respectively.
+  you must use a container image of `devkitpro/devkitarm` and mount
+  `/var/run/docker.sock:/var/run/docker.sock` into the container so that the
+  runner image can be built by the action.
 
 inputs:
   args:
@@ -34,6 +34,8 @@ runs:
         tags: ${{ inputs.runner-image }}:latest
         push: false
         load: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Ensure docker is installed in the container
       shell: bash

--- a/run-tests/action.yml
+++ b/run-tests/action.yml
@@ -44,20 +44,24 @@ runs:
     - name: Run cargo 3ds test
       shell: bash
       # Set a custom runner for `cargo test` commands to use.
-      # Use ${GITHUB_WORKSPACE} due to
+      # Use ${PWD} and ${RUNNER_TEMP} due to
       # https://github.com/actions/runner/issues/2058, which also means
-      # we have to export this instead of using the env: key
+      # we have to export this in `run` instead of using the `env` key
       run: |
         cd ${{ inputs.working-directory }}
+
+        # Hopefully this still works if the input is an absolute path:
+        mounted_pwd="${{ github.workspace }}/${{ inputs.working-directory }}"
+
         export CARGO_TARGET_ARMV6K_NINTENDO_3DS_RUNNER="
             docker run --rm
-                -v ${{ runner.temp }}:${{ runner.temp }}
-                -v ${{ github.workspace }}/target:/app/target
                 -v ${{ github.workspace }}:${GITHUB_WORKSPACE}
+                -v ${mounted_pwd}/target:/app/target
+                -v ${{ runner.temp }}:${RUNNER_TEMP}
                 ${{ inputs.runner-image }}:latest"
         env
         cargo 3ds -v test ${{ inputs.args }}
       env:
-        # Ensure that doctests get built into a path which is mounted on the host
-        # as well as in this container (via the bind mount in the RUNNER command)
-        TMPDIR: ${{ runner.temp }}
+        # Make sure doctests are built into the shared tempdir instead of the
+        # container's /tmp which will be immediately removed
+        TMPDIR: ${{ env.RUNNER_TEMP }}

--- a/test-runner/src/console.rs
+++ b/test-runner/src/console.rs
@@ -1,8 +1,9 @@
+use std::process::Termination;
+
 use ctru::prelude::*;
 use ctru::services::gfx::{Flush, Swap};
 
 use super::TestRunner;
-use crate::TestResult;
 
 pub struct ConsoleRunner {
     gfx: Gfx,
@@ -29,11 +30,10 @@ impl TestRunner for ConsoleRunner {
         Console::new(self.gfx.top_screen.borrow_mut())
     }
 
-    fn cleanup<T: TestResult>(mut self, result: T) -> T {
-        // We don't actually care about the test result, either way we'll stop
-        // and show the results to the user
+    fn cleanup<T: Termination>(mut self, result: T) -> T {
+        // We don't actually care about the output of the test result, either
+        // way we'll stop and show the results to the user.
 
-        // Wait to make sure the user can actually see the results before we exit
         println!("Press START to exit.");
 
         while self.apt.main_loop() {

--- a/test-runner/src/console.rs
+++ b/test-runner/src/console.rs
@@ -2,6 +2,7 @@ use ctru::prelude::*;
 use ctru::services::gfx::{Flush, Swap};
 
 use super::TestRunner;
+use crate::TestResult;
 
 pub struct ConsoleRunner {
     gfx: Gfx,
@@ -28,7 +29,7 @@ impl TestRunner for ConsoleRunner {
         Console::new(self.gfx.top_screen.borrow_mut())
     }
 
-    fn cleanup(mut self, _test_result: std::io::Result<bool>) {
+    fn cleanup<T: TestResult>(mut self, result: T) -> T {
         // We don't actually care about the test result, either way we'll stop
         // and show the results to the user
 
@@ -47,5 +48,7 @@ impl TestRunner for ConsoleRunner {
                 break;
             }
         }
+
+        result
     }
 }

--- a/test-runner/src/gdb.rs
+++ b/test-runner/src/gdb.rs
@@ -1,6 +1,7 @@
 use ctru::error::ResultCode;
 
 use super::TestRunner;
+use crate::TestResult;
 
 #[derive(Default)]
 pub struct GdbRunner;
@@ -27,22 +28,10 @@ impl TestRunner for GdbRunner {
         .expect("failed to redirect I/O streams to GDB");
     }
 
-    fn cleanup(self, test_result: std::io::Result<bool>) {
+    fn cleanup<T: TestResult>(self, test_result: T) -> T {
         // GDB actually has the opportunity to inspect the exit code,
         // unlike other runners, so let's follow the default behavior of the
         // stdlib test runner.
-        match test_result {
-            Ok(success) => {
-                if success {
-                    std::process::exit(0);
-                } else {
-                    std::process::exit(101);
-                }
-            }
-            Err(err) => {
-                eprintln!("Error: {err}");
-                std::process::exit(101);
-            }
-        }
+        std::process::exit(if test_result.succeeded() { 0 } else { 101 })
     }
 }

--- a/test-runner/src/gdb.rs
+++ b/test-runner/src/gdb.rs
@@ -1,7 +1,8 @@
+use std::process::Termination;
+
 use ctru::error::ResultCode;
 
 use super::TestRunner;
-use crate::TestResult;
 
 #[derive(Default)]
 pub struct GdbRunner;
@@ -28,10 +29,10 @@ impl TestRunner for GdbRunner {
         .expect("failed to redirect I/O streams to GDB");
     }
 
-    fn cleanup<T: TestResult>(self, test_result: T) -> T {
+    fn cleanup<T: Termination>(self, test_result: T) -> T {
         // GDB actually has the opportunity to inspect the exit code,
         // unlike other runners, so let's follow the default behavior of the
         // stdlib test runner.
-        std::process::exit(if test_result.succeeded() { 0 } else { 101 })
+        test_result.report().exit_process()
     }
 }

--- a/test-runner/src/lib.rs
+++ b/test-runner/src/lib.rs
@@ -13,6 +13,7 @@ extern crate test;
 
 mod console;
 mod gdb;
+mod macros;
 mod socket;
 
 use std::process::{ExitCode, Termination};
@@ -46,106 +47,6 @@ pub fn run_console(tests: &[&TestDescAndFn]) {
 /// [`Soc::redirect_to_3dslink`]: ctru::services::soc::Soc::redirect_to_3dslink
 pub fn run_socket(tests: &[&TestDescAndFn]) {
     run::<SocketRunner>(tests);
-}
-
-// Use a neat little trick with cfg(doctest) to make code fences appear in
-// rustdoc output, but still compile normally when doctesting. This raises warnings
-// for invalid code though, so we also silence that lint here.
-#[cfg_attr(not(doctest), allow(rustdoc::invalid_rust_codeblocks))]
-/// Helper macro for writing doctests using this runner. Wrap this macro around
-/// your normal doctest to enable running it with the test runners in this crate.
-///
-/// You may optionally specify a runner before the test body, and may use any of
-/// the various [`fn main()`](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#using--in-doc-tests)
-/// signatures allowed by documentation tests.
-///
-/// # Examples
-///
-/// ## Basic usage
-///
-#[cfg_attr(not(doctest), doc = "````")]
-/// ```
-/// test_runner::doctest! {
-///     assert_eq!(2 + 2, 4);
-/// }
-/// ```
-#[cfg_attr(not(doctest), doc = "````")]
-///
-/// ## Custom runner
-///
-#[cfg_attr(not(doctest), doc = "````")]
-/// ```no_run
-/// test_runner::doctest! { SocketRunner,
-///     assert_eq!(2 + 2, 4);
-/// }
-/// ```
-#[cfg_attr(not(doctest), doc = "````")]
-///
-/// ## `should_panic`
-///
-#[cfg_attr(not(doctest), doc = "````")]
-/// ```should_panic
-/// test_runner::doctest! {
-///     assert_eq!(2 + 2, 5);
-/// }
-/// ```
-#[cfg_attr(not(doctest), doc = "````")]
-///
-/// ## Custom `fn main`
-///
-#[cfg_attr(not(doctest), doc = "````")]
-/// ```
-/// test_runner::doctest! {
-///     fn main() {
-///         assert_eq!(2 + 2, 4);
-///     }
-/// }
-/// ```
-#[cfg_attr(not(doctest), doc = "````")]
-///
-#[cfg_attr(not(doctest), doc = "````")]
-/// ```
-/// test_runner::doctest! {
-///     fn main() -> Result<(), Box<dyn std::error::Error>> {
-///         assert_eq!(2 + 2, 4);
-///         Ok(())
-///     }
-/// }
-/// ```
-#[cfg_attr(not(doctest), doc = "````")]
-///
-/// ## Implicit return type
-///
-/// Note that for the rustdoc preprocessor to understand the return type, the
-/// `Ok(())` expression must be written _outside_ the `doctest!` invocation.
-///
-#[cfg_attr(not(doctest), doc = "````")]
-/// ```
-/// test_runner::doctest! {
-///     assert_eq!(2 + 2, 4);
-/// }
-/// Ok::<(), std::io::Error>(())
-/// ```
-#[cfg_attr(not(doctest), doc = "````")]
-#[macro_export]
-macro_rules! doctest {
-    ($runner:ident, fn main() $(-> $ret:ty)? { $($body:tt)* } ) => {
-        fn main() $(-> $ret)? {
-            $crate::doctest!{ $runner, $($body)* }
-        }
-    };
-    ($runner:ident, $($body:tt)*) => {
-        use $crate::TestRunner as _;
-        let mut _runner = $crate::$runner::default();
-        _runner.setup();
-        let _result = { $($body)* };
-        _runner.cleanup(_result)
-    };
-    ($($body:tt)*) => {
-        $crate::doctest!{ GdbRunner,
-            $($body)*
-        }
-    };
 }
 
 fn run<Runner: TestRunner>(tests: &[&TestDescAndFn]) {

--- a/test-runner/src/lib.rs
+++ b/test-runner/src/lib.rs
@@ -61,6 +61,16 @@ pub fn run_socket(tests: &[&TestDescAndFn]) {
 ///
 /// # Examples
 ///
+/// ## Basic usage
+///
+#[cfg_attr(not(doctest), doc = "````")]
+/// ```
+/// test_runner::doctest! {
+///     assert_eq!(2 + 2, 4);
+/// }
+/// ```
+#[cfg_attr(not(doctest), doc = "````")]
+///
 /// ## Custom runner
 ///
 #[cfg_attr(not(doctest), doc = "````")]

--- a/test-runner/src/lib.rs
+++ b/test-runner/src/lib.rs
@@ -48,6 +48,10 @@ pub fn run_socket(tests: &[&TestDescAndFn]) {
     run::<SocketRunner>(tests);
 }
 
+// Use a neat little trick with cfg(doctest) to make code fences appear in
+// rustdoc output, but still compile normally when doctesting. This raises warnings
+// for invalid code though, so we also silence that lint here.
+#[cfg_attr(not(doctest), allow(rustdoc::invalid_rust_codeblocks))]
 /// Helper macro for writing doctests using this runner. Wrap this macro around
 /// your normal doctest to enable running it with the test runners in this crate.
 ///
@@ -59,22 +63,27 @@ pub fn run_socket(tests: &[&TestDescAndFn]) {
 ///
 /// ## Custom runner
 ///
+#[cfg_attr(not(doctest), doc = "````")]
 /// ```no_run
 /// test_runner::doctest! { SocketRunner,
 ///     assert_eq!(2 + 2, 4);
 /// }
 /// ```
+#[cfg_attr(not(doctest), doc = "````")]
 ///
 /// ## `should_panic`
 ///
+#[cfg_attr(not(doctest), doc = "````")]
 /// ```should_panic
 /// test_runner::doctest! {
 ///     assert_eq!(2 + 2, 5);
 /// }
 /// ```
+#[cfg_attr(not(doctest), doc = "````")]
 ///
 /// ## Custom `fn main`
 ///
+#[cfg_attr(not(doctest), doc = "````")]
 /// ```
 /// test_runner::doctest! {
 ///     fn main() {
@@ -82,7 +91,9 @@ pub fn run_socket(tests: &[&TestDescAndFn]) {
 ///     }
 /// }
 /// ```
+#[cfg_attr(not(doctest), doc = "````")]
 ///
+#[cfg_attr(not(doctest), doc = "````")]
 /// ```
 /// test_runner::doctest! {
 ///     fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -91,18 +102,21 @@ pub fn run_socket(tests: &[&TestDescAndFn]) {
 ///     }
 /// }
 /// ```
+#[cfg_attr(not(doctest), doc = "````")]
 ///
 /// ## Implicit return type
 ///
 /// Note that for the rustdoc preprocessor to understand the return type, the
 /// `Ok(())` expression must be written _outside_ the `doctest!` invocation.
 ///
+#[cfg_attr(not(doctest), doc = "````")]
 /// ```
 /// test_runner::doctest! {
 ///     assert_eq!(2 + 2, 4);
 /// }
 /// Ok::<(), std::io::Error>(())
 /// ```
+#[cfg_attr(not(doctest), doc = "````")]
 #[macro_export]
 macro_rules! doctest {
     ($runner:ident, fn main() $(-> $ret:ty)? { $($body:tt)* } ) => {
@@ -227,9 +241,6 @@ mod link_fix {
         -1
     }
 }
-
-#[cfg(doctest)]
-struct Dummy;
 
 #[cfg(test)]
 mod tests {

--- a/test-runner/src/macros.rs
+++ b/test-runner/src/macros.rs
@@ -1,0 +1,101 @@
+//! Macros for working with test runners.
+
+// Use a neat little trick with cfg(doctest) to make code fences appear in
+// rustdoc output, but still compile normally when doctesting. This raises warnings
+// for invalid code though, so we also silence that lint here.
+#[cfg_attr(not(doctest), allow(rustdoc::invalid_rust_codeblocks))]
+/// Helper macro for writing doctests using this runner. Wrap this macro around
+/// your normal doctest to enable running it with the test runners in this crate.
+///
+/// You may optionally specify a runner before the test body, and may use any of
+/// the various [`fn main()`](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#using--in-doc-tests)
+/// signatures allowed by documentation tests.
+///
+/// # Examples
+///
+/// ## Basic usage
+///
+#[cfg_attr(not(doctest), doc = "````")]
+/// ```
+/// test_runner::doctest! {
+///     assert_eq!(2 + 2, 4);
+/// }
+/// ```
+#[cfg_attr(not(doctest), doc = "````")]
+///
+/// ## Custom runner
+///
+#[cfg_attr(not(doctest), doc = "````")]
+/// ```no_run
+/// test_runner::doctest! { SocketRunner,
+///     assert_eq!(2 + 2, 4);
+/// }
+/// ```
+#[cfg_attr(not(doctest), doc = "````")]
+///
+/// ## `should_panic`
+///
+#[cfg_attr(not(doctest), doc = "````")]
+/// ```should_panic
+/// test_runner::doctest! {
+///     assert_eq!(2 + 2, 5);
+/// }
+/// ```
+#[cfg_attr(not(doctest), doc = "````")]
+///
+/// ## Custom `fn main`
+///
+#[cfg_attr(not(doctest), doc = "````")]
+/// ```
+/// test_runner::doctest! {
+///     fn main() {
+///         assert_eq!(2 + 2, 4);
+///     }
+/// }
+/// ```
+#[cfg_attr(not(doctest), doc = "````")]
+///
+#[cfg_attr(not(doctest), doc = "````")]
+/// ```
+/// test_runner::doctest! {
+///     fn main() -> Result<(), Box<dyn std::error::Error>> {
+///         assert_eq!(2 + 2, 4);
+///         Ok(())
+///     }
+/// }
+/// ```
+#[cfg_attr(not(doctest), doc = "````")]
+///
+/// ## Implicit return type
+///
+/// Note that for the rustdoc preprocessor to understand the return type, the
+/// `Ok(())` expression must be written _outside_ the `doctest!` invocation.
+///
+#[cfg_attr(not(doctest), doc = "````")]
+/// ```
+/// test_runner::doctest! {
+///     assert_eq!(2 + 2, 4);
+/// }
+/// Ok::<(), std::io::Error>(())
+/// ```
+#[cfg_attr(not(doctest), doc = "````")]
+#[macro_export]
+macro_rules! doctest {
+    ($runner:ident, fn main() $(-> $ret:ty)? { $($body:tt)* } ) => {
+        fn main() $(-> $ret)? {
+            $crate::doctest!{ $runner, $($body)* }
+        }
+    };
+    ($runner:ident, $($body:tt)*) => {
+        use $crate::TestRunner as _;
+        let mut _runner = $crate::$runner::default();
+        _runner.setup();
+        let _result = { $($body)* };
+        _runner.cleanup(_result)
+    };
+    ($($body:tt)*) => {
+        $crate::doctest!{ GdbRunner,
+            $($body)*
+        }
+    };
+}

--- a/test-runner/src/socket.rs
+++ b/test-runner/src/socket.rs
@@ -22,6 +22,4 @@ impl TestRunner for SocketRunner {
             .redirect_to_3dslink(true, true)
             .expect("failed to redirect to socket");
     }
-
-    fn cleanup(self, _test_result: std::io::Result<bool>) {}
 }


### PR DESCRIPTION
Fixes #4

This works by providing a macro that can be used in doctests to properly setup + teardown the GDB runner. The API could probably be fleshed out a bit to support console runners and stuff but works in CI for now.